### PR TITLE
Give the release job permissions to write to the repository content

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,8 @@ jobs:
         
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: build
     steps:
       - name: Download x86-64 binaries


### PR DESCRIPTION
This allows the "release" job to create a release