### PR TITLE
Get build and release workflow working

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         run: cmake -S src -B build-${{ matrix.arch }} -G "Visual Studio 17 2022" -A ${{ matrix.arch }}
 
       - name: Build
-        run: cmake --build build-${{ matrix.arch }} --config Release
+        run: cmake --build build-${{ matrix.arch }} --config RelWithDebInfo
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,21 +58,14 @@ jobs:
           cp build-ARM64/* release/
           zip -r release/ShellExecuteEx-${{ github.run_number }}-windows.zip release/*
 
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Create release and upload assets
+        uses: softprops/action-gh-release@v2
         with:
+          files: |
+            release/ShellExecuteEx-${{ github.run_number }}-windows.zip
           tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           draft: false
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload zip to release
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: release/ShellExecuteEx-${{ github.run_number }}-windows.zip
-          asset_name: ShellExecuteEx-${{ github.run_number }}-windows.zip
-          asset_content_type: application/zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,8 +30,8 @@ jobs:
         with:
           name: ShellExecuteEx-${{ matrix.arch }}
           path: |
-            build-${{ matrix.arch }}/Release/*.exe
-            build-${{ matrix.arch }}/Release/*.pdb
+            build-${{ matrix.arch }}/RelWithDebInfo/*.exe
+            build-${{ matrix.arch }}/RelWithDebInfo/*.pdb
         
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,5 +74,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: release/ShellExecuteEx-${{ github.run_number }}-windows.zip
-          asset-name: ShellExecuteEx-${{ github.run_number }}-windows.zip
+          asset_name: ShellExecuteEx-${{ github.run_number }}-windows.zip
           asset_content_type: application/zip


### PR DESCRIPTION
Workflow runs either manually through the GitHub UI or when a commit is tagged with 'v*'. Built binaries are not signed