### PR TITLE
Move architecture out of client .yaml files into common .yaml file

### DIFF
--- a/.github/workflows/after-merge.yaml
+++ b/.github/workflows/after-merge.yaml
@@ -9,7 +9,6 @@ jobs:
     uses: ./.github/workflows/common-build.yml
     with:
       build-dir: main-build
-      arch-matrix: [x64, ARM64]
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/before-merge.yaml
+++ b/.github/workflows/before-merge.yaml
@@ -9,4 +9,3 @@ jobs:
     uses: ./.github/workflows/common-build.yaml
     with:
       build-dir: private-branch-build
-      arch-matrix: [x64, ARM64]

--- a/.github/workflows/common-build.yaml
+++ b/.github/workflows/common-build.yaml
@@ -6,16 +6,13 @@ on:
       build-dir:
         required: true
         type: string
-      arch-matrix:
-        required: true
-        type: string
 
 jobs:
   build:
     runs-on: windows-latest
     strategy:
       matrix:
-        arch: ${{ inputs.arch-matrix }}
+        arch: [x64, arm64]
 
       steps:
         - name: Checkout source


### PR DESCRIPTION
Can't pass a matrix to a child workflow without smuggling into a string, which is overly complicated for what I'm doing