### PR TITLE
Test return codes of various paths through wmain

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if (MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 endif()
 
-# for the ShellExecutExW API implementation
+# for the ShellExecuteExW API implementation
 link_libraries(Shell32)
 
 # embed the version in resources.rc

--- a/src/main-internal.cpp
+++ b/src/main-internal.cpp
@@ -1,18 +1,15 @@
 #include "common.h"
 
-int wmain_internal(int argc, LPCWSTR argv[], FNSHELLEXECUTEXW fn_api) {
+int wmain_internal(int argc, LPCWSTR argv[], FNSHELLEXECUTEEXW fn_api) {
     bool run = false;
-    Prefs p; // inherits from SHELLEXECUTEOPTIONSW
+    Prefs p; // inherits from SHELLEXECUTEINFOW
     if (p.Parse(argc, argv, run)) {
         if (run) {
             // actually invoke the API and log the result
             BOOL result = fn_api(&p);
             DWORD error = (result ? ERROR_SUCCESS : GetLastError());
-            p.LogResult(result);
-            LOG(L"Result of ShellExecutExW: %d", result);
-            if (!result) {
-                return error;
-            }
+            p.LogResult(result, error);
+            return (result ? 0 : error);
         } else {
             // just a usage statement
             return 0;
@@ -21,4 +18,6 @@ int wmain_internal(int argc, LPCWSTR argv[], FNSHELLEXECUTEXW fn_api) {
         // parsing failed
         return ERROR_INVALID_PARAMETER;
     }
+
+    // unreachable
 }

--- a/src/main-internal.h
+++ b/src/main-internal.h
@@ -1,4 +1,4 @@
 // main-internal.h
 
-typedef BOOL (*FNSHELLEXECUTEXW)(LPSHELLEXECUTEINFOW);
-int wmain_internal(int argc, LPCWSTR argv[], FNSHELLEXECUTEXW api);
+typedef BOOL (*FNSHELLEXECUTEEXW)(LPSHELLEXECUTEINFOW);
+int wmain_internal(int argc, LPCWSTR argv[], FNSHELLEXECUTEEXW api);

--- a/src/prefs.cpp
+++ b/src/prefs.cpp
@@ -390,15 +390,14 @@ void Prefs::ShowUsage() {
     }
 }
 
-void Prefs::LogResult(BOOL result) {
-    LOG(L"ShellExecute %s", (result ? L"succeeded" : L"failed"));
+void Prefs::LogResult(BOOL result, DWORD error) {
+    LOG(L"ShellExecuteExW %s", (result ? L"succeeded" : L"failed"));
     if (result) {
         LOG(L"hProcess: 0x%p", hProcess);
         if (hProcess != nullptr) {
             CloseHandle(hProcess);
         }
     } else {
-        DWORD error = GetLastError();
         LOG(L"Last error: %d", error);
     }
     LOG(L"hInstApp: 0x%p", hInstApp);

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -4,7 +4,7 @@ class Prefs : public SHELLEXECUTEINFOW {
 public:
     Prefs(); 
     bool Parse(int argc, LPCWSTR argv[], bool &run);
-    void LogResult(BOOL result);
+    void LogResult(BOOL result, DWORD error);
 
 private:
     static bool IsUsage(int argc, LPCWSTR argv[]);

--- a/src/tests/main-return.cpp
+++ b/src/tests/main-return.cpp
@@ -1,13 +1,66 @@
 #include "test-common.h"
 
+// set this to false
+// then attempt to invoke MockShellExecuteExW
+//
+// if it's true afterwards, MockShellExecuteExW was invoked
 bool g_shellExecuteCalled = false;
 
+// make a MockShellExecuteExW that behaves however you want
+template<BOOL forceResult, DWORD forceError>
 BOOL MockShellExecuteExW(LPSHELLEXECUTEINFOW info) {
-    LOG(L"%s", L"Inside MockShellExecuteExW");
+    LOG(L"Inside MockShellExecuteExW<forceResult=%d, forceError=%d>", forceResult, forceError);
 
+    // report that we were invoked
     g_shellExecuteCalled = true;
 
-    return TRUE;
+    // behave as directed
+    if (!forceResult) {
+        SetLastError(forceError);
+    }
+
+    return forceResult;
+}
+
+// Valid parameters should
+// - call ShellExecuteExW
+// - if ShellExecuteExW succeeds, return 0
+TEST(Main, ShellExecuteSucceeds) {
+    LPCWSTR notepad_args[] = {
+        L"shellexecuteex.exe",
+        L"--file", L"notepad.exe",
+        L"--show", L"SW_NORMAL"
+    };
+
+    g_shellExecuteCalled = false;
+    EXPECT_EQ(0, wmain_internal(
+        _countof(notepad_args),
+        notepad_args,
+        MockShellExecuteExW<TRUE, ERROR_SUCCESS>
+    ));
+    EXPECT_TRUE(g_shellExecuteCalled);
+    // no expectation on GetLastError()
+}
+
+// Valid parameters should
+// - call ShellExecuteExW
+// - if ShellExecuteExW fails, return the error code it sets
+TEST(Main, ShellExecuteFails) {
+    LPCWSTR notepad_args[] = {
+        L"shellexecuteex.exe",
+        L"--file", L"notepad.exe",
+        L"--show", L"SW_NORMAL"
+    };
+
+    const DWORD customError = 123456789;
+
+    g_shellExecuteCalled = false;
+    EXPECT_EQ(customError, wmain_internal(
+        _countof(notepad_args),
+        notepad_args,
+        MockShellExecuteExW<FALSE, customError>
+    ));
+    EXPECT_TRUE(g_shellExecuteCalled);
 }
 
 // Invoking a usage statement should
@@ -36,8 +89,24 @@ TEST(Main, Usage) {
         EXPECT_EQ(0, wmain_internal(
             a.argc,
             a.argv,
-            MockShellExecuteExW
+            MockShellExecuteExW<TRUE, ERROR_SUCCESS>
         ));
         EXPECT_FALSE(g_shellExecuteCalled);
     }
+}
+
+// An invalid parameter should
+// - not call ShellExecuteExW
+// - return a non-zero error code
+TEST(Main, InvalidParameter) {
+    LPCWSTR invalid_args[] = { L"shellexecuteex.exe", L"--foo" };
+
+    g_shellExecuteCalled = false;
+    // any non-zero error code is fine
+    EXPECT_NE(0, wmain_internal(
+        _countof(invalid_args),
+        invalid_args,
+        MockShellExecuteExW<TRUE, ERROR_SUCCESS>
+    ));
+    EXPECT_FALSE(g_shellExecuteCalled);
 }


### PR DESCRIPTION
One of the code paths in `wmain_internal` didn't return an error code. Test all the paths